### PR TITLE
Diff

### DIFF
--- a/okpt/diff/diff.py
+++ b/okpt/diff/diff.py
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Provides the Diff class."""
+
+from typing import Any, Dict, Tuple
+
+
+class InconsistentTestResultsError(Exception):
+    """Exception raised when two test results have different keys.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, key: str, result: str):
+        self.message = f'key `{key}` is not present in {result}.'
+        super().__init__(self.message)
+
+
+class InvalidTestResultsType(Exception):
+    """Exception raised when a test result has non-numeric test result values.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, key: str, result: str):
+        self.message = f'key `{key}` in {result} points to a non-numeric value.'
+        super().__init__(self.message)
+
+
+def _is_numeric(a) -> bool:
+    return type(a) == int or type(a) == float
+
+
+class Diff:
+    """Diff class for validating and diffing two test result files.
+
+    Methods:
+        diff: Returns the diff between two test results. (right minus left)
+    """
+
+    def __init__(self, l_result: Dict[str, Any], r_result: Dict[str, Any]):
+        """Initializes test results and validate them."""
+        self.l_result = l_result
+        self.r_result = r_result
+
+        # validate test results
+        is_valid, key, result = self._validate_structure()
+        if not is_valid:
+            raise InconsistentTestResultsError(key, result)
+        is_valid, key, result = self._validate_types()
+        if not is_valid:
+            raise InvalidTestResultsType(key, result)
+
+    def _validate_structure(self) -> Tuple[bool, str, str]:
+        """Ensure both test results have the same keys."""
+        for k in self.l_result:
+            if not k in self.r_result:
+                return (False, k, 'right_result')
+        for k in self.r_result:
+            if not k in self.l_result:
+                return (False, k, 'left_result')
+        return (True, '', '')
+
+    def _validate_types(self) -> Tuple[bool, str, str]:
+        """Ensure both test results have numeric values."""
+        for k, v in self.l_result.items():
+            if not _is_numeric(v):
+                return (False, k, 'left_result')
+        for k, v in self.r_result.items():
+            if not _is_numeric(v):
+                return (False, k, 'right_result')
+        return (True, '', '')
+
+    def diff(self) -> Dict[str, Any]:
+        """Return the diff between the two test results. (right minus left)"""
+        return {
+            key: self.r_result[key] - self.l_result[key]
+            for key in self.l_result
+            if isinstance(self.l_result[key], int) or
+            isinstance(self.l_result[key], float)
+        }

--- a/okpt/diff/diff.py
+++ b/okpt/diff/diff.py
@@ -44,7 +44,7 @@ class InvalidTestResultsType(Exception):
 
 
 def _is_numeric(a) -> bool:
-    return type(a) == int or type(a) == float
+    return isinstance(a, (int, float))
 
 
 class Diff:
@@ -92,6 +92,4 @@ class Diff:
         return {
             key: self.r_result[key] - self.l_result[key]
             for key in self.l_result
-            if isinstance(self.l_result[key], int) or
-            isinstance(self.l_result[key], float)
         }

--- a/okpt/diff/diff.py
+++ b/okpt/diff/diff.py
@@ -19,39 +19,14 @@
 from typing import Any, Dict, Tuple
 
 
-class InconsistentTestResultsError(Exception):
-    """Exception raised when two test results have different keys.
+class InvalidTestResultsError(Exception):
+    """Exception raised when the test results are invalid.
 
-    Attributes:
-        message -- explanation of the error
+    The results can be invalid if they have different fields, non-numeric
+    values, or if they don't follow the standard result format.
     """
-
-    def __init__(self, key: str, result: str):
-        self.message = f'key `{key}` is not present in {result}.'
-        super().__init__(self.message)
-
-
-class InvalidTestResultTypeError(Exception):
-    """Exception raised when a test result has non-numeric test result values.
-
-    Attributes:
-        message -- explanation of the error
-    """
-
-    def __init__(self, key: str, result: str):
-        self.message = f'key `{key}` in {result} points to a non-numeric value.'
-        super().__init__(self.message)
-
-
-class InvalidTestResultError(Exception):
-    """Exception raised when a test result has missing or invalid fields.
-
-    Attributes:
-        message -- explanation of the error
-    """
-
-    def __init__(self, key: str, result: str):
-        self.message = f'{result} has a missing or invalid key `{key}`.'
+    def __init__(self, msg: str):
+        self.message = msg
         super().__init__(self.message)
 
 
@@ -65,39 +40,55 @@ class Diff:
     Methods:
         diff: Returns the diff between two test results. (changed - base)
     """
-
-    def __init__(self, base_result: Dict[str, Any],
-                 changed_result: Dict[str, Any], metadata: bool):
+    def __init__(
+        self,
+        base_result: Dict[str,
+                          Any],
+        changed_result: Dict[str,
+                             Any],
+        metadata: bool
+    ):
         """Initializes test results and validate them."""
         self.base_result = base_result
         self.changed_result = changed_result
         self.metadata = metadata
 
-        # validate test result keys
+        # make sure results have proper test result fields
         is_valid, key, result = self._validate_keys()
         if not is_valid:
-            raise InvalidTestResultError(key, result)
+            raise InvalidTestResultsError(
+                f'{result} has a missing or invalid key `{key}`.'
+            )
 
         self.base_results = self.base_result['results']
         self.changed_results = self.changed_result['results']
 
-        # validate test result structure and types
+        # make sure results have the same fields
         is_valid, key, result = self._validate_structure()
         if not is_valid:
-            raise InconsistentTestResultsError(key, result)
+            raise InvalidTestResultsError(
+                f'key `{key}` is not present in {result}.'
+            )
+
+        # make sure results have numeric values
         is_valid, key, result = self._validate_types()
         if not is_valid:
-            raise InvalidTestResultTypeError(key, result)
+            raise InvalidTestResultsError(
+                f'key `{key}` in {result} points to a non-numeric value.'
+            )
 
     def _validate_keys(self) -> Tuple[bool, str, str]:
         """Ensure both test results have `metadata` and `results` keys."""
         check_keydict = lambda key, res: key in res and isinstance(
             res[key], dict)
+
+        # check if results have a `metadata` field and if `metadata` is a dict
         if self.metadata:
             if not check_keydict('metadata', self.base_result):
                 return (False, 'metadata', 'base_result')
             if not check_keydict('metadata', self.changed_result):
                 return (False, 'metadata', 'changed_result')
+        # check if results have a `results` field and `results` is a dict
         if not check_keydict('results', self.base_result):
             return (False, 'results', 'base_result')
         if not check_keydict('results', self.changed_result):

--- a/okpt/diff/diff.py
+++ b/okpt/diff/diff.py
@@ -56,8 +56,8 @@ class Diff:
 
     def __init__(self, l_result: Dict[str, Any], r_result: Dict[str, Any]):
         """Initializes test results and validate them."""
-        self.l_result = l_result
-        self.r_result = r_result
+        self.l_result = l_result['results']
+        self.r_result = r_result['results']
 
         # validate test results
         is_valid, key, result = self._validate_structure()

--- a/okpt/diff/diff.py
+++ b/okpt/diff/diff.py
@@ -31,7 +31,7 @@ class InconsistentTestResultsError(Exception):
         super().__init__(self.message)
 
 
-class InvalidTestResultType(Exception):
+class InvalidTestResultTypeError(Exception):
     """Exception raised when a test result has non-numeric test result values.
 
     Attributes:
@@ -43,7 +43,7 @@ class InvalidTestResultType(Exception):
         super().__init__(self.message)
 
 
-class InvalidTestResult(Exception):
+class InvalidTestResultError(Exception):
     """Exception raised when a test result has missing or invalid fields.
 
     Attributes:
@@ -76,7 +76,7 @@ class Diff:
         # validate test result keys
         is_valid, key, result = self._validate_keys()
         if not is_valid:
-            raise InvalidTestResult(key, result)
+            raise InvalidTestResultError(key, result)
 
         self.base_results = self.base_result['results']
         self.changed_results = self.changed_result['results']
@@ -87,7 +87,7 @@ class Diff:
             raise InconsistentTestResultsError(key, result)
         is_valid, key, result = self._validate_types()
         if not is_valid:
-            raise InvalidTestResultType(key, result)
+            raise InvalidTestResultTypeError(key, result)
 
     def _validate_keys(self) -> Tuple[bool, str, str]:
         """Ensure both test results have `metadata` and `results` keys."""

--- a/okpt/io/args.py
+++ b/okpt/io/args.py
@@ -40,11 +40,11 @@ def _add_config_path_arg(parser, name, help_msg='Path of configuration file.'):
 
 
 # TODO: add custom nargs for 2 or more args instead of 1
-def _add_results_paths_arg(parser, name, help_msg='Paths of results files.'):
+def _add_result_paths_arg(parser, name, help_msg='Paths of results files.'):
     """"Add results files paths argument."""
     parser.add_argument(
         name,
-        type=_writable_file_type,
+        type=_readable_file_type,
         nargs='+',
         help=help_msg,
     )
@@ -68,13 +68,13 @@ def _add_test_subcommand(subparsers):
 
 def _add_diff_subcommand(subparsers):
     diff_parser = subparsers.add_parser('diff')
-    _add_results_paths_arg(diff_parser, 'result_paths')
-    _add_output_path_arg(diff_parser, 'output_path')
+    _add_result_paths_arg(diff_parser, 'result_paths')
+    _add_output_path_arg(diff_parser, '--output_path')
 
 
 def _add_plot_subcommand(subparsers):
     plot_parser = subparsers.add_parser('plot')
-    _add_results_paths_arg(plot_parser, 'result_paths')
+    _add_result_paths_arg(plot_parser, 'result_paths')
     _add_output_path_arg(plot_parser, 'output_path')
 
 
@@ -86,14 +86,21 @@ _parser = argparse.ArgumentParser(
 
 def define_args():
     """Define tool commands."""
-    _parser.add_argument(
-        '--log',
-        type=str,
-        choices=['debug', 'info', 'warning', 'error', 'critical'],
-        default='info')
-    subparsers = _parser.add_subparsers(title='commands',
-                                        dest='command',
-                                        help='sub-command help')
+    _parser.add_argument('--log',
+                         type=str,
+                         choices=[
+                             'debug',
+                             'info',
+                             'warning',
+                             'error',
+                             'critical',
+                         ],
+                         default='info')
+    subparsers = _parser.add_subparsers(
+        title='commands',
+        dest='command',
+        help='sub-command help',
+    )
     subparsers.required = True
 
     # add subcommands

--- a/okpt/io/args.py
+++ b/okpt/io/args.py
@@ -28,7 +28,7 @@ import argparse
 import sys
 from dataclasses import dataclass
 from io import TextIOWrapper
-from typing import List, Union
+from typing import Union
 
 _read_type = argparse.FileType('r')
 _write_type = argparse.FileType('w')
@@ -96,21 +96,19 @@ def _add_test_cmd(subparsers):
 def _add_diff_cmd(subparsers):
     diff_parser = subparsers.add_parser('diff')
     _add_metadata(diff_parser, '--metadata')
-    _add_result(diff_parser,
-                'base_result',
-                help='Base test result.',
-                metavar='base_result')
-    _add_result(diff_parser,
-                'changed_result',
-                help='Changed test result.',
-                metavar='changed_result')
+    _add_result(
+        diff_parser,
+        'base_result',
+        help='Base test result.',
+        metavar='base_result'
+    )
+    _add_result(
+        diff_parser,
+        'changed_result',
+        help='Changed test result.',
+        metavar='changed_result'
+    )
     _add_output(diff_parser, '--output', default=sys.stdout)
-
-
-def _add_plot_cmd(subparsers):
-    plot_parser = subparsers.add_parser('plot')
-    _add_results(plot_parser, 'results')
-    _add_output(plot_parser, 'output')
 
 
 @dataclass
@@ -131,15 +129,7 @@ class DiffArgs:
     output: TextIOWrapper
 
 
-@dataclass
-class PlotArgs:
-    log: str
-    command: str
-    results: List[TextIOWrapper]
-    output: TextIOWrapper
-
-
-def get_args() -> Union[TestArgs, DiffArgs, PlotArgs]:
+def get_args() -> Union[TestArgs, DiffArgs]:
     """Define, parse and return command line args.
 
     Returns:
@@ -158,35 +148,40 @@ def get_args() -> Union[TestArgs, DiffArgs, PlotArgs]:
             '--log',
             default='info',
             type=str,
-            choices=['debug', 'info', 'warning', 'error', 'critical'],
-            help='Log level of the tool.')
+            choices=['debug',
+                     'info',
+                     'warning',
+                     'error',
+                     'critical'],
+            help='Log level of the tool.'
+        )
 
-        subparsers = parser.add_subparsers(title='commands',
-                                           dest='command',
-                                           help='sub-command help')
+        subparsers = parser.add_subparsers(
+            title='commands',
+            dest='command',
+            help='sub-command help'
+        )
         subparsers.required = True
 
         # add subcommands
         _add_test_cmd(subparsers)
         _add_diff_cmd(subparsers)
-        _add_plot_cmd(subparsers)
 
     define_args()
     args = parser.parse_args()
     if args.command == 'test':
-        return TestArgs(log=args.log,
-                        command=args.command,
-                        config=args.config,
-                        output=args.output)
-    elif args.command == 'diff':
-        return DiffArgs(log=args.log,
-                        command=args.command,
-                        metadata=args.metadata,
-                        base_result=args.base_result,
-                        changed_result=args.changed_result,
-                        output=args.output)
+        return TestArgs(
+            log=args.log,
+            command=args.command,
+            config=args.config,
+            output=args.output
+        )
     else:
-        return PlotArgs(log=args.log,
-                        command=args.command,
-                        results=args.results,
-                        output=args.output)
+        return DiffArgs(
+            log=args.log,
+            command=args.command,
+            metadata=args.metadata,
+            base_result=args.base_result,
+            changed_result=args.changed_result,
+            output=args.output
+        )

--- a/okpt/io/args.py
+++ b/okpt/io/args.py
@@ -34,7 +34,7 @@ _read_type = argparse.FileType('r')
 _write_type = argparse.FileType('w')
 
 
-def _add_config_path(parser, name, **kwargs):
+def _add_config(parser, name, **kwargs):
     """"Add configuration file path argument."""
     opts = {
         'type': _read_type,
@@ -45,7 +45,7 @@ def _add_config_path(parser, name, **kwargs):
     parser.add_argument(name, **opts)
 
 
-def _add_result_path(parser, name, **kwargs):
+def _add_result(parser, name, **kwargs):
     """"Add results files paths argument."""
     opts = {
         'type': _read_type,
@@ -57,7 +57,7 @@ def _add_result_path(parser, name, **kwargs):
 
 
 # TODO: add custom nargs for 2 or more args instead of 1
-def _add_result_paths(parser, name, **kwargs):
+def _add_results(parser, name, **kwargs):
     """"Add results files paths argument."""
     opts = {
         'nargs': '+',
@@ -69,7 +69,7 @@ def _add_result_paths(parser, name, **kwargs):
     parser.add_argument(name, **opts)
 
 
-def _add_output_path(parser, name, **kwargs):
+def _add_output(parser, name, **kwargs):
     """"Add output file path argument."""
     opts = {
         'type': _write_type,
@@ -80,29 +80,38 @@ def _add_output_path(parser, name, **kwargs):
     parser.add_argument(name, **opts)
 
 
-def _add_test_subcommand(subparsers):
+def _add_metadata(parser, name, **kwargs):
+    opts = {
+        'action': 'store_true',
+        **kwargs,
+    }
+    parser.add_argument(name, **opts)
+
+
+def _add_test_cmd(subparsers):
     test_parser = subparsers.add_parser('test')
-    _add_config_path(test_parser, 'config')
-    _add_output_path(test_parser, 'output')
+    _add_config(test_parser, 'config')
+    _add_output(test_parser, 'output')
 
 
-def _add_diff_subcommand(subparsers):
+def _add_diff_cmd(subparsers):
     diff_parser = subparsers.add_parser('diff')
-    _add_result_path(diff_parser,
-                     'l_result',
-                     help='Base test result.',
-                     metavar='base_result')
-    _add_result_path(diff_parser,
-                     'r_result',
-                     help='Changed test result.',
-                     metavar='changed_result')
-    _add_output_path(diff_parser, '--output', default=sys.stdout)
+    _add_metadata(diff_parser, '--metadata')
+    _add_result(diff_parser,
+                'l_result',
+                help='Base test result.',
+                metavar='base_result')
+    _add_result(diff_parser,
+                'r_result',
+                help='Changed test result.',
+                metavar='changed_result')
+    _add_output(diff_parser, '--output', default=sys.stdout)
 
 
-def _add_plot_subcommand(subparsers):
+def _add_plot_cmd(subparsers):
     plot_parser = subparsers.add_parser('plot')
-    _add_result_paths(plot_parser, 'results')
-    _add_output_path(plot_parser, 'output')
+    _add_results(plot_parser, 'results')
+    _add_output(plot_parser, 'output')
 
 
 @dataclass
@@ -117,6 +126,7 @@ class TestArgs:
 class DiffArgs:
     log: str
     command: str
+    metadata: bool
     l_result: TextIOWrapper
     r_result: TextIOWrapper
     output: TextIOWrapper
@@ -158,9 +168,9 @@ def get_args() -> Union[TestArgs, DiffArgs, PlotArgs]:
         subparsers.required = True
 
         # add subcommands
-        _add_test_subcommand(subparsers)
-        _add_diff_subcommand(subparsers)
-        _add_plot_subcommand(subparsers)
+        _add_test_cmd(subparsers)
+        _add_diff_cmd(subparsers)
+        _add_plot_cmd(subparsers)
 
     define_args()
     args = parser.parse_args()
@@ -172,6 +182,7 @@ def get_args() -> Union[TestArgs, DiffArgs, PlotArgs]:
     elif args.command == 'diff':
         return DiffArgs(log=args.log,
                         command=args.command,
+                        metadata=args.metadata,
                         l_result=args.l_result,
                         r_result=args.r_result,
                         output=args.output)

--- a/okpt/io/args.py
+++ b/okpt/io/args.py
@@ -25,9 +25,9 @@ Functions:
 """
 
 import argparse
+import sys
 from dataclasses import dataclass
 from io import TextIOWrapper
-import sys
 from typing import List, Union
 
 _read_type = argparse.FileType('r')

--- a/okpt/io/args.py
+++ b/okpt/io/args.py
@@ -98,11 +98,11 @@ def _add_diff_cmd(subparsers):
     diff_parser = subparsers.add_parser('diff')
     _add_metadata(diff_parser, '--metadata')
     _add_result(diff_parser,
-                'l_result',
+                'base_result',
                 help='Base test result.',
                 metavar='base_result')
     _add_result(diff_parser,
-                'r_result',
+                'changed_result',
                 help='Changed test result.',
                 metavar='changed_result')
     _add_output(diff_parser, '--output', default=sys.stdout)
@@ -127,8 +127,8 @@ class DiffArgs:
     log: str
     command: str
     metadata: bool
-    l_result: TextIOWrapper
-    r_result: TextIOWrapper
+    base_result: TextIOWrapper
+    changed_result: TextIOWrapper
     output: TextIOWrapper
 
 
@@ -183,8 +183,8 @@ def get_args() -> Union[TestArgs, DiffArgs, PlotArgs]:
         return DiffArgs(log=args.log,
                         command=args.command,
                         metadata=args.metadata,
-                        l_result=args.l_result,
-                        r_result=args.r_result,
+                        base_result=args.base_result,
+                        changed_result=args.changed_result,
                         output=args.output)
     else:
         return PlotArgs(log=args.log,

--- a/okpt/io/args.py
+++ b/okpt/io/args.py
@@ -56,7 +56,6 @@ def _add_result(parser, name, **kwargs):
     parser.add_argument(name, **opts)
 
 
-# TODO: add custom nargs for 2 or more args instead of 1
 def _add_results(parser, name, **kwargs):
     """"Add results files paths argument."""
     opts = {

--- a/okpt/io/config/parsers/base.py
+++ b/okpt/io/config/parsers/base.py
@@ -37,9 +37,10 @@ class ConfigurationError(Exception):
     Attributes:
         message -- explanation of the error
     """
+
     def __init__(self, message: str):
-        super().__init__()
-        self.message = f'Configuration Syntax Error: {message}'
+        self.message = f'{message}'
+        super().__init__(self.message)
 
 
 class BaseParser():
@@ -52,6 +53,7 @@ class BaseParser():
     Methods:
         parse: Parse config.
     """
+
     def __init__(self, schema_name: str):
         self.validator = self._get_validator_from_schema_name(schema_name)
         self.errors = ''

--- a/okpt/io/utils/writer.py
+++ b/okpt/io/utils/writer.py
@@ -23,7 +23,7 @@ Functions:
 
 import json
 from io import TextIOWrapper
-from typing import Any, Dict
+from typing import Any, Dict, TextIO, Union
 
 
 def get_file_obj(path: str) -> TextIOWrapper:
@@ -38,11 +38,14 @@ def get_file_obj(path: str) -> TextIOWrapper:
     return open(path, 'w')
 
 
-def write_json(data: Dict[str, Any], file: TextIOWrapper):
+def write_json(data: Dict[str, Any],
+               file: Union[TextIOWrapper, TextIO],
+               pretty=False):
     """Writes a dictionary to a JSON file.
 
     Args:
         data: A dict to write to JSON.
         file: Path of output file.
     """
-    json.dump(data, file)
+    indent = 2 if pretty else 0
+    json.dump(data, file, indent=indent)

--- a/okpt/main.py
+++ b/okpt/main.py
@@ -56,11 +56,12 @@ def main():
         cli_args = cast(args.DiffArgs, cli_args)
 
         # parse test results
-        l_result = reader.parse_json(cli_args.l_result)
-        r_result = reader.parse_json(cli_args.r_result)
+        base_result = reader.parse_json(cli_args.base_result)
+        changed_result = reader.parse_json(cli_args.changed_result)
 
         # get diff
-        diff_result = diff.Diff(l_result, r_result).diff()
+        diff_result = diff.Diff(base_result, changed_result,
+                                cli_args.metadata).diff()
         writer.write_json(data=diff_result, file=output, pretty=True)
     elif cli_args.command == 'plot':
         pass  # TODO

--- a/okpt/main.py
+++ b/okpt/main.py
@@ -16,21 +16,19 @@
 # under the License.
 """ Runner script that serves as the main controller of the testing tool."""
 
-import json
 import logging
+import sys
 from typing import cast
 from okpt.diff import diff
-import sys
 
 from okpt.io import args
-from okpt.io.config.parsers import base, tool
+from okpt.io.config.parsers import tool
 from okpt.io.utils import reader, writer
 from okpt.test import runner
 
 
 def main():
     """Main function of entry module."""
-    args.define_args()
     cli_args = args.get_args()
     output = cli_args.output
     if cli_args.log:
@@ -50,16 +48,19 @@ def main():
         test_result = test_runner.execute()
 
         # write test results
-        logging.debug(f'Test Result:\n {json.dumps(test_result, indent=2)}')
-        writer.write_json(data=test_result, file=output)
+        logging.debug(
+            f'Test Result:\n {writer.write_json(test_result, sys.stdout, pretty=True)}'
+        )
+        writer.write_json(test_result, output, pretty=True)
     elif cli_args.command == 'diff':
         cli_args = cast(args.DiffArgs, cli_args)
 
         # parse test results
-        l_result, r_result = [reader.parse_json(r) for r in cli_args.results]
+        l_result = reader.parse_json(cli_args.l_result)
+        r_result = reader.parse_json(cli_args.r_result)
 
         # get diff
         diff_result = diff.Diff(l_result, r_result).diff()
-        print(json.dumps(diff_result, indent=2))
+        writer.write_json(data=diff_result, file=output, pretty=True)
     elif cli_args.command == 'plot':
         pass  # TODO

--- a/okpt/main.py
+++ b/okpt/main.py
@@ -19,8 +19,8 @@
 import logging
 import sys
 from typing import cast
-from okpt.diff import diff
 
+from okpt.diff import diff
 from okpt.io import args
 from okpt.io.config.parsers import tool
 from okpt.io.utils import reader, writer

--- a/okpt/test/runner.py
+++ b/okpt/test/runner.py
@@ -117,7 +117,9 @@ class TestRunner():
 
         # add metadata to test results
         tool_result = {
-            **self._get_metadata(), 'aggregate':
+            'metadata':
+                self._get_metadata(),
+            'results':
                 aggregate,
             'test_parameters':
                 dataclasses.asdict(self.tool_config.test_parameters)

--- a/okpt/test/steps/base.py
+++ b/okpt/test/steps/base.py
@@ -16,8 +16,9 @@
 # under the License.
 """Provides base Step interface."""
 
-from okpt.test import profile
 from typing import Any, Dict, List
+
+from okpt.test import profile
 
 
 class Step:

--- a/okpt/test/steps/nmslib.py
+++ b/okpt/test/steps/nmslib.py
@@ -21,8 +21,8 @@ so the functions in this module may return a blank dictionary in order to be
 profiled.
 """
 from typing import Any, Dict, List, cast
-import h5py
 
+import h5py
 import nmslib
 import numpy as np
 

--- a/okpt/test/steps/opensearch.py
+++ b/okpt/test/steps/opensearch.py
@@ -19,12 +19,13 @@
 Some of the OpenSearch operations return a `took` field in the response body,
 so the profiling decorators aren't needed for some functions.
 """
-from okpt.test.steps import base
 from typing import Any, Dict, List, cast
 
 import elasticsearch
-import numpy as np
 import h5py
+import numpy as np
+
+from okpt.test.steps import base
 
 
 class CreateIndexStep(base.Step):

--- a/okpt/test/tests/factory.py
+++ b/okpt/test/tests/factory.py
@@ -15,8 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 """Provides a factory class for tests."""
-from okpt.test.tests import base as base_t, opensearch, nmslib
-from okpt.io.config.parsers import tool, base as base_p
+from okpt.io.config.parsers import base as base_p
+from okpt.io.config.parsers import tool
+from okpt.test.tests import base as base_t
+from okpt.test.tests import nmslib, opensearch
 
 _tests = {
     'opensearch_index': opensearch.OpenSearchIndexTest,


### PR DESCRIPTION
resolves #19

This PR implements the tool's `diff` command. It gives the tool the ability to take in two test results and generate a diff between the results, similar to what `git diff` tries to do with commits. By default, the tool pretty prints the diff output to stdout.

The tool's argument parsing has been refactored to extend it to `diff` and other commands. It adds the specific `diff` command requirements along with its optional arguments (flags).

A `Diff` class is added to help validate and generate the actual diff. The validation includes verifying the format of the test results and ensuring that they are comparable. Some custom exceptions have been created to better indicate the potential input errors.

The optional flags are adding metadata (`--metadata`) and redirecting output to a file (`--output <file-path.json>`). Currently, key filtering (`--keys key1, key2,...`) has not yet been implemented though some of the code added and refactored in this PR already implements the majority of the key filtering logic, so adding that feature shouldn't be too difficult.